### PR TITLE
Updated AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.ml.quaterion.facenetdetection">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
@@ -11,6 +12,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:requestLegacyExternalStorage="true"
         android:theme="@style/AppTheme">
 
         <meta-data


### PR DESCRIPTION
Updated AndroidManifest for READ_EXTERNAL_STORAGE permission.
To work on Samsung A51, with Android 10, adding these two new parameters on the Android manifest was necessary. Maybe it can help others spend less time looking for the reason why the app is not working on the device.